### PR TITLE
debug用のPush通知画面を作成

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Cache node_modules PeperomiaWeb
+      uses: actions/cache@preview
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-PeperomiaWeb-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
+        restore-keys:
+          ${{ runner.os }}-PeperomiaWeb-
     - name: Install node_modules PeperomiaWeb
+      if: steps.cache.outputs.cache-hit != 'true'
       run: yarn install
     - name: setup
       run: sh localInit.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install node_modules PeperomiaWeb
-      if: steps.cache.outputs.cache-hit != 'true'
       run: yarn install
     - name: setup
       run: sh localInit.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,13 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Cache node_modules PeperomiaWeb
-      uses: actions/cache@preview
-      with:
-        path: ~/.cache/yarn
-        key: ${{ runner.os }}-PeperomiaWeb-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
-        restore-keys:
-          ${{ runner.os }}-PeperomiaWeb-
     - name: Install node_modules PeperomiaWeb
       if: steps.cache.outputs.cache-hit != 'true'
       run: yarn install

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jwt-decode": "^2.2.0",
     "node-sass": "^4.13.1",
     "nuxt": "latest",
-    "peperomia-util": "^0.0.14",
+    "peperomia-util": "^0.0.17",
     "sass-loader": "^8.0.2",
     "style-loader": "^1.2.0",
     "vuex-persistedstate": "^2.7.1",

--- a/pages/notifications/index.vue
+++ b/pages/notifications/index.vue
@@ -1,0 +1,92 @@
+<template>
+  <div class="root">
+    <v-sheet elevation="4" width="500">
+      <v-form v-model="state.valid" class="form">
+        <h3>Push通知送信</h3>
+        <v-text-field v-model="state.uuid" label="uuid" :rules="[required]" />
+
+        <v-text-field
+          v-model="state.title"
+          label="タイトル"
+          :rules="[required]"
+        />
+
+        <v-textarea
+          v-model="state.body"
+          label="本文"
+          auto-grow
+          rows="1"
+          :rules="[required]"
+        />
+
+        <v-text-field v-model="state.urlScheme" label="URLスキーマ" />
+
+        <div class="my-5">
+          <v-btn color="primary" large @click="onPushNotidication">
+            送信する
+          </v-btn>
+        </div>
+      </v-form>
+    </v-sheet>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.root {
+  padding: 1rem 2rem;
+}
+
+.form {
+  padding: 1rem 2rem;
+}
+</style>
+
+<script lang="ts">
+import { defineComponent, reactive, SetupContext } from '@vue/composition-api'
+import { post } from '~/modules/fetch.ts'
+
+type State = {
+  loading: boolean
+  uuid: string
+  title: string
+  body: string
+  urlScheme: string
+  valid: boolean
+}
+
+const initialState = () => ({
+  uuid: '',
+  title: '',
+  body: '',
+  urlScheme: '',
+  loading: false,
+  valid: false,
+})
+
+export default defineComponent({
+  setup(_, ctx: SetupContext) {
+    const state = reactive<State>(initialState())
+
+    const onPushNotidication = async () => {
+      state.loading = true
+
+      await post(ctx, 'admin/SentPushNotifications', {
+        uid: state.uuid,
+        title: state.title,
+        body: state.body,
+        urlScheme: state.urlScheme,
+      })
+
+      state.loading = false
+    }
+
+    const required = (value: string) => !!value || '必須です.'
+
+    return {
+      state,
+      required,
+      onPushNotidication,
+    }
+  },
+})
+</script>

--- a/store/user.ts
+++ b/store/user.ts
@@ -1,0 +1,31 @@
+import { ActionTree, MutationTree, GetterTree } from 'vuex'
+import {
+  USER_ROLE_GENERAL,
+  USER_ROLE_ADMIN,
+} from 'peperomia-util/build/domain/user'
+
+export const state = () => ({
+  role: USER_ROLE_GENERAL,
+})
+
+type State = ReturnType<typeof state>
+
+export const actions: ActionTree<any, State> = {
+  setRole({ commit }, { role }) {
+    console.log(role)
+
+    commit('SET_ROLE', role)
+  },
+}
+
+export const getters: GetterTree<any, State> = {
+  isAdmin({ role }) {
+    return role === USER_ROLE_ADMIN
+  },
+}
+
+export const mutations: MutationTree<State> = {
+  SET_ROLE: (state, role) => {
+    state.role = role
+  },
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10919,10 +10919,10 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-peperomia-util@^0.0.14:
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/peperomia-util/-/peperomia-util-0.0.14.tgz#38eb72dc8e3c4821c2642bc2573c032e5987e970"
-  integrity sha512-tBnToWtpA2253XYaz7SMbR00vpgZJxTN37T0AX7sXMzw3Tf0InRUs5J0bIcQZKLh7WwheP/Fp5iqKn/xayOkPw==
+peperomia-util@^0.0.17:
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/peperomia-util/-/peperomia-util-0.0.17.tgz#a63e0db5bc824add0675a1fc90dad72fb3825907"
+  integrity sha512-ISVk8Xsjgvr0YSENRZvFnDEpoOXYRCteaLVuVKmsL8bEDn7fTY7PShIMY8OaZQS413qstfVLDuqsf5oCfusq4g==
   dependencies:
     dayjs "^1.8.22"
     firebase "^7.10.0"


### PR DESCRIPTION
## 関連 issue

- fixes #32

## 対応内容
 - デバッグ用にpush通知を送る画面を作成
 - この機能はユーザーの権限設定がadminで無いとメニューに表示されないように修正

<img width="625" alt="スクリーンショット 2020-06-25 21 15 43" src="https://user-images.githubusercontent.com/19209314/85718712-bb2c3480-b729-11ea-9c95-021ba1cfff33.png">

![IMG_FC212D7DA4B5-1](https://user-images.githubusercontent.com/19209314/85718669-b1a2cc80-b729-11ea-98a1-6c060168f079.jpeg)




## 開発用メモ
無し

