### PR TITLE
カレンダーPush通知のデバッグ機能追加

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -202,6 +202,11 @@ export default defineComponent({
             title: 'ユーザー通知',
             to: '/notifications',
           },
+          {
+            icon: 'mdi-dev-to',
+            title: 'デバッグ機能',
+            to: '/debug',
+          },
         ]
       }
 

--- a/modules/fetch.ts
+++ b/modules/fetch.ts
@@ -9,7 +9,18 @@ export const post = async (context: SetupContext, path: string, param: any) => {
   context.root.$http.setHeader('Content-Type', 'application/json')
   context.root.$http.setHeader('Authorization', `Bearer ${token}`)
 
-  const res = await context.root.$http.post(`${BASE_URL}/${path}`, param)
+  const res = await context.root.$http.post(`${BASE_URL}${path}`, param)
+
+  return res
+}
+
+export const get = async (context: SetupContext, path: string) => {
+  const token = await getAccessToken(context)
+
+  context.root.$http.setHeader('Content-Type', 'application/json')
+  context.root.$http.setHeader('Authorization', `Bearer ${token}`)
+
+  const res = await context.root.$http.get(`${BASE_URL}${path}`)
 
   return res
 }

--- a/pages/debug/index.vue
+++ b/pages/debug/index.vue
@@ -1,0 +1,84 @@
+<template>
+  <div class="root">
+    <v-sheet elevation="4" width="400">
+      <v-form v-model="state.sendCalendarPushNotifications.valid" class="form">
+        <h3>カレンダー当日通知</h3>
+
+        <v-date-picker
+          v-model="state.sendCalendarPushNotifications.date"
+          :rules="[required]"
+          :day-format="(date) => new Date(date).getDate()"
+          locale="jp-ja"
+        />
+
+        <div class="my-5">
+          <v-btn color="primary" large @click="onSendCalendarPushNotifications">
+            送信する
+          </v-btn>
+        </div>
+      </v-form>
+    </v-sheet>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.root {
+  padding: 1rem 2rem;
+}
+
+.form {
+  padding: 1rem 2rem;
+}
+</style>
+
+<script lang="ts">
+import { defineComponent, reactive, SetupContext } from '@vue/composition-api'
+import dayjs from 'dayjs'
+import advancedFormat from 'dayjs/plugin/advancedFormat'
+import { get } from '~/modules/fetch.ts'
+
+dayjs.extend(advancedFormat)
+
+type State = {
+  loading: boolean
+  sendCalendarPushNotifications: {
+    valid: boolean
+    date: string
+  }
+}
+
+const initialState = () => ({
+  loading: false,
+  sendCalendarPushNotifications: {
+    valid: false,
+    date: dayjs().format('YYYY-MM-DD'),
+  },
+})
+
+export default defineComponent({
+  setup(_, ctx: SetupContext) {
+    const state = reactive<State>(initialState())
+
+    const onSendCalendarPushNotifications = async () => {
+      state.loading = true
+
+      console.log(state.sendCalendarPushNotifications.date)
+
+      await get(
+        ctx,
+        `cron/SendCalendarPushNotifications?date=${state.sendCalendarPushNotifications.date}T00:00:00`
+      )
+
+      state.loading = false
+    }
+
+    const required = (value: string) => !!value || '必須です.'
+
+    return {
+      state,
+      required,
+      onSendCalendarPushNotifications,
+    }
+  },
+})
+</script>


### PR DESCRIPTION
## 関連 issue

- fixes #38

## 対応内容

<img width="638" alt="スクリーンショット 2020-07-05 19 21 04" src="https://user-images.githubusercontent.com/19209314/86531058-0f3cd300-bef9-11ea-9516-7fd2b395d03f.png">


 - カレンダー当日のPush通知送信のデバッグ画面作成

## 開発用メモ
無し

