### PR TITLE
composition-apiのリファクタリング

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "eslint.enable": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": false
+  },
+  "cSpell.ignoreWords": ["firestore", "peperomia", "Nuxt"],
+  "editor.formatOnSave": true
+}

--- a/components/molecules/calendar/day.vue
+++ b/components/molecules/calendar/day.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="root">
     <div class="no-event" :style="fontStyle">
-      {{ dayjs(props.date).format('D') }}
+      {{ dayjs(date).format('D') }}
     </div>
   </div>
 </template>
@@ -35,12 +35,12 @@ type Props = {
   size: number
 }
 
-export default defineComponent({
+export default defineComponent<Props>({
   props: {
     date: { type: String, default: '' },
     size: { type: Number, default: 1 },
   },
-  setup(props: Props) {
+  setup(props) {
     const fontStyle = computed(() => {
       return {
         fontSize: `${1.2 * props.size}rem`,
@@ -50,7 +50,6 @@ export default defineComponent({
     return {
       fontStyle,
       dayjs,
-      props,
     }
   },
 })

--- a/components/molecules/calendar/scheduleDay.vue
+++ b/components/molecules/calendar/scheduleDay.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="root" :style="bg" @click="onOenItemDialog(props.itemID)">
+  <div class="root" :style="bg" @click="onOenItemDialog(itemID)">
     <div class="event" :style="fontStyle">
-      {{ dayjs(props.date).format('D') }}
+      {{ dayjs(date).format('D') }}
     </div>
     <div>
-      <v-img :src="props.kindData.src" class="kind-img" :style="imgStyle" />
+      <v-img :src="kindData.src" class="kind-img" :style="imgStyle" />
     </div>
   </div>
 </template>
@@ -33,7 +33,7 @@
 </style>
 
 <script lang="ts">
-import { defineComponent, computed, SetupContext } from '@vue/composition-api'
+import { defineComponent, computed } from '@vue/composition-api'
 import dayjs from 'dayjs'
 import advancedFormat from 'dayjs/plugin/advancedFormat'
 import { Kind } from 'peperomia-util/build/getKind'
@@ -46,14 +46,14 @@ type Props = {
   size: number
 }
 
-export default defineComponent({
+export default defineComponent<Props>({
   props: {
     date: { type: String, default: '' },
     itemID: { type: String, default: '' },
     kindData: { type: Object, default: () => {} },
     size: { type: Number, default: 1 },
   },
-  setup(props: Props, context: SetupContext) {
+  setup(props, ctx) {
     const bg = computed(() => {
       return {
         backgroundColor: props.kindData.backgroundColor || '#FFF',
@@ -72,7 +72,7 @@ export default defineComponent({
     })
 
     const onOenItemDialog = (id: string) => {
-      context.root.$store.commit('OPEN_ITEM_DIALOG', {
+      ctx.root.$store.commit('OPEN_ITEM_DIALOG', {
         id,
       })
     }
@@ -82,7 +82,6 @@ export default defineComponent({
       imgStyle,
       fontStyle,
       dayjs,
-      props,
       onOenItemDialog,
     }
   },

--- a/components/organisms/calendar/calendar.vue
+++ b/components/organisms/calendar/calendar.vue
@@ -68,7 +68,7 @@ const defaultCalendarItem: CalendarItem = {
   kind: '',
 }
 
-export default defineComponent({
+export default defineComponent<Props>({
   components: {
     day,
     scheduleDay,
@@ -78,7 +78,7 @@ export default defineComponent({
     calendarDate: { type: String, required: true },
     calendars: { type: Array, default: () => [] },
   },
-  setup(props: Props) {
+  setup(props) {
     const isSchedule = (date: string): boolean => {
       const item = props.calendars.find((v) => v.date === date)
 

--- a/components/organisms/schedule/card.vue
+++ b/components/organisms/schedule/card.vue
@@ -5,7 +5,7 @@
       min-height="60"
       class="root"
       :style="bg"
-      @click="onEditItemDetail(props.itemDetail.id)"
+      @click="onEditItemDetail(itemDetail.id)"
     >
       <div class="header-card">
         <div class="header-card-title">
@@ -13,13 +13,13 @@
             <v-img :src="kindData.src" width="30" height="30" />
           </div>
           <div class="card-title pl-3 pt-5">
-            {{ props.itemDetail.title }}
+            {{ itemDetail.title }}
           </div>
         </div>
       </div>
       <div>
         <div class="px-2">
-          <template v-if="props.itemDetail.place">
+          <template v-if="itemDetail.place">
             <v-chip
               class="chip-container"
               color="themeLightGray"
@@ -35,11 +35,11 @@
               </div>
             </v-chip>
             <div class="label-value">
-              {{ props.itemDetail.place }}
+              {{ itemDetail.place }}
             </div>
           </template>
 
-          <template v-if="props.itemDetail.url">
+          <template v-if="itemDetail.url">
             <v-chip
               class="chip-container"
               color="themeLightGray"
@@ -53,11 +53,11 @@
               <div class="label-text">URL</div>
             </v-chip>
             <div class="label-value">
-              <a :href="props.itemDetail.url">{{ props.itemDetail.url }}</a>
+              <a :href="itemDetail.url">{{ itemDetail.url }}</a>
             </div>
           </template>
 
-          <template v-if="props.itemDetail.memo">
+          <template v-if="itemDetail.memo">
             <v-chip
               class="chip-container"
               color="themeLightGray"
@@ -70,7 +70,7 @@
               </v-icon>
               <div class="label-text">メモ</div>
             </v-chip>
-            <div class="label-value">{{ props.itemDetail.memo }}</div>
+            <div class="label-value">{{ itemDetail.memo }}</div>
           </template>
         </div>
       </div>
@@ -134,12 +134,12 @@ type Props = {
   onEditItemDetail: (itemDetailId: string) => void
 }
 
-export default defineComponent({
+export default defineComponent<Props>({
   props: {
     itemDetail: { type: Object, required: true },
     onEditItemDetail: { type: Function, default: () => {} },
   },
-  setup(props: Props) {
+  setup(props) {
     const kindData = KINDS[props.itemDetail.kind]
 
     const bg = computed(() => {
@@ -149,7 +149,6 @@ export default defineComponent({
     })
 
     return {
-      props,
       kindData,
       bg,
     }

--- a/components/organisms/schedule/edit.vue
+++ b/components/organisms/schedule/edit.vue
@@ -9,7 +9,7 @@
       <div class="inner pt-4">
         <div>
           <v-text-field
-            v-model="state.title"
+            v-model="title"
             label="タイトル"
             single-line
             autofocus
@@ -17,14 +17,14 @@
         </div>
       </div>
       <div class="edit-action">
-        <v-btn color="error" class="edit-button" text @click="props.onCancel">
+        <v-btn color="error" class="edit-button" text @click="onCancel">
           キャンセル
         </v-btn>
         <v-btn
           color="primary"
           class="edit-button"
-          :loading="props.loading"
-          :disabled="props.loading"
+          :loading="loading"
+          :disabled="loading"
           @click="onSaveItem"
         >
           保存
@@ -100,7 +100,12 @@
 </style>
 
 <script lang="ts">
-import { defineComponent, computed, reactive } from '@vue/composition-api'
+import {
+  defineComponent,
+  computed,
+  reactive,
+  toRefs,
+} from '@vue/composition-api'
 import dayjs from 'dayjs'
 import advancedFormat from 'dayjs/plugin/advancedFormat'
 import { KINDS } from 'peperomia-util'
@@ -119,14 +124,14 @@ type Props = {
 
 dayjs.extend(advancedFormat)
 
-export default defineComponent({
+export default defineComponent<Props>({
   props: {
     loading: { type: Boolean, default: false },
     item: { type: Object, default: () => {} },
     onCancel: { type: Function, default: () => {} },
     onSave: { type: Function, default: () => {} },
   },
-  setup(props: Props) {
+  setup(props) {
     const state = reactive<State>({
       title: props.item.title,
     })
@@ -149,8 +154,7 @@ export default defineComponent({
     }
 
     return {
-      props,
-      state,
+      ...toRefs(state),
       kindData,
       bg,
       onSaveItem,

--- a/components/organisms/schedule/index.vue
+++ b/components/organisms/schedule/index.vue
@@ -1,9 +1,9 @@
 <template>
   <v-sheet elevation="4" max-width="500">
-    <div v-if="!props.loading">
+    <div v-if="!loading">
       <div class="header-itme" :style="bg">
         <v-menu
-          v-if="props.edit"
+          v-if="edit"
           v-model="menu"
           :close-on-content-click="false"
           :nudge-right="40"
@@ -25,8 +25,8 @@
             <v-btn text color="error" @click="menu = false">キャンセル</v-btn>
             <v-btn
               color="primary"
-              :loading="props.apiLoading"
-              :disabled="props.apiLoading"
+              :loading="apiLoading"
+              :disabled="apiLoading"
               @click="onSaveCalendarData"
             >
               保存
@@ -40,20 +40,20 @@
           <div class="pr-3 py-3">
             <v-img :src="kindData.src" width="60" height="60" />
           </div>
-          <div class="item-title pl-5 pt-8" @click="props.onEditItem">
-            {{ props.item.title }}
+          <div class="item-title pl-5 pt-8" @click="onEditItem">
+            {{ item.title }}
           </div>
         </div>
       </div>
       <div class="item-body">
         <div
-          v-for="itemDetail in props.itemDetails"
+          v-for="itemDetail in itemDetails"
           :key="itemDetail.id"
           class="pa-3"
         >
           <card
             :item-detail="itemDetail"
-            :on-edit-item-detail="props.onEditItemDetail"
+            :on-edit-item-detail="onEditItemDetail"
           />
         </div>
       </div>
@@ -127,7 +127,7 @@ type Props = {
 
 dayjs.extend(advancedFormat)
 
-export default defineComponent({
+export default defineComponent<Props>({
   components: {
     card,
   },
@@ -142,7 +142,7 @@ export default defineComponent({
     onEditItemDetail: { type: Function, default: () => {} },
     onSaveCalendar: { type: Function, default: () => {} },
   },
-  setup(props: Props) {
+  setup(props) {
     const menu = ref<boolean>(false)
     const date = ref<string>(props.calendar.date)
 
@@ -168,7 +168,6 @@ export default defineComponent({
     }
 
     return {
-      props,
       kindData,
       bg,
       dayjs,

--- a/components/organisms/scheduleDetail/edit.vue
+++ b/components/organisms/scheduleDetail/edit.vue
@@ -6,13 +6,13 @@
           <v-img :src="kindData.src" width="40" height="40" />
         </div>
         <div class="item-title pt-3">
-          <v-text-field v-model="state.title" single-line />
+          <v-text-field v-model="title" single-line />
         </div>
       </div>
       <div class="px-6">
         <div>
           <v-text-field
-            v-model="state.place"
+            v-model="place"
             label="場所"
             prepend-icon="mdi-map-marker-outline"
             color="themeLightGreen"
@@ -21,7 +21,7 @@
         </div>
         <div>
           <v-text-field
-            v-model="state.url"
+            v-model="url"
             label="URL"
             prepend-icon="mdi-link"
             color="themeLightGreen"
@@ -30,7 +30,7 @@
         </div>
         <div>
           <v-textarea
-            v-model="state.memo"
+            v-model="memo"
             label="メモ"
             prepend-icon="mdi-view-list"
             color="themeLightGreen"
@@ -40,14 +40,14 @@
         </div>
       </div>
       <div class="edit-action">
-        <v-btn color="error" class="edit-button" text @click="props.onCancel">
+        <v-btn color="error" class="edit-button" text @click="onCancel">
           キャンセル
         </v-btn>
         <v-btn
           color="primary"
           class="edit-button"
-          :loading="props.loading"
-          :disabled="props.loading"
+          :loading="loading"
+          :disabled="loading"
           @click="onSaveItemDetail"
         >
           保存
@@ -126,7 +126,12 @@
 </style>
 
 <script lang="ts">
-import { defineComponent, computed, reactive } from '@vue/composition-api'
+import {
+  defineComponent,
+  computed,
+  reactive,
+  toRefs,
+} from '@vue/composition-api'
 import dayjs from 'dayjs'
 import advancedFormat from 'dayjs/plugin/advancedFormat'
 import { KINDS } from 'peperomia-util'
@@ -149,14 +154,14 @@ type Props = {
 
 dayjs.extend(advancedFormat)
 
-export default defineComponent({
+export default defineComponent<Props>({
   props: {
     loading: { type: Boolean, default: false },
     itemDetail: { type: Object, default: () => {} },
     onCancel: { type: Function, default: () => {} },
     onSave: { type: Function, default: () => {} },
   },
-  setup(props: Props) {
+  setup(props) {
     const state = reactive<State>({
       title: props.itemDetail.title,
       kind: props.itemDetail.kind,
@@ -183,8 +188,7 @@ export default defineComponent({
     }
 
     return {
-      props,
-      state,
+      ...toRefs(state),
       kindData,
       bg,
       onSaveItemDetail,

--- a/components/templates/dashboard/calendar.vue
+++ b/components/templates/dashboard/calendar.vue
@@ -85,14 +85,14 @@ type State = {
   small: boolean
 }
 
-export default defineComponent({
+export default defineComponent<Props>({
   components: {
     calendar,
   },
   props: {
     calendars: { type: Array, default: () => [] },
   },
-  setup(props: Props) {
+  setup(props) {
     const main = ref<any>(null)
 
     const getDate = (month: number) => {

--- a/components/templates/login/index.vue
+++ b/components/templates/login/index.vue
@@ -133,14 +133,11 @@
 import { defineComponent } from '@vue/composition-api'
 import { LoginType } from '~/pages/login.vue'
 
-export default defineComponent({
+type Props = LoginType
+
+export default defineComponent<Props>({
   props: {
     fbGoogleLogin: { type: Function, required: true },
-  },
-  setup(props: LoginType) {
-    return {
-      fbGoogleLogin: props.fbGoogleLogin,
-    }
   },
 })
 </script>

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -12,6 +12,12 @@
   </v-app>
 </template>
 
+<style scoped>
+h1 {
+  font-size: 20px;
+}
+</style>
+
 <script>
 export default {
   layout: 'empty',
@@ -36,9 +42,3 @@ export default {
   },
 }
 </script>
-
-<style scoped>
-h1 {
-  font-size: 20px;
-}
-</style>

--- a/pages/debug/index.vue
+++ b/pages/debug/index.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="root">
     <v-sheet elevation="4" width="400">
-      <v-form v-model="state.sendCalendarPushNotifications.valid" class="form">
+      <v-form v-model="sendCalendarPushNotifications.valid" class="form">
         <h3>カレンダー当日通知</h3>
 
         <v-date-picker
-          v-model="state.sendCalendarPushNotifications.date"
+          v-model="sendCalendarPushNotifications.date"
           :rules="[required]"
           :day-format="(date) => new Date(date).getDate()"
           locale="jp-ja"
@@ -32,7 +32,12 @@
 </style>
 
 <script lang="ts">
-import { defineComponent, reactive, SetupContext } from '@vue/composition-api'
+import {
+  defineComponent,
+  reactive,
+  SetupContext,
+  toRefs,
+} from '@vue/composition-api'
 import dayjs from 'dayjs'
 import advancedFormat from 'dayjs/plugin/advancedFormat'
 import { get } from '~/modules/fetch.ts'
@@ -75,7 +80,7 @@ export default defineComponent({
     const required = (value: string) => !!value || '必須です.'
 
     return {
-      state,
+      ...toRefs(state),
       required,
       onSendCalendarPushNotifications,
     }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <CalendarView :calendars="state.calendars" />
+    <CalendarView :calendars="calendars" />
   </div>
 </template>
 
@@ -11,6 +11,7 @@ import {
   onUnmounted,
   reactive,
   SetupContext,
+  toRefs,
 } from '@vue/composition-api'
 import CalendarView from '~/components/templates/dashboard/calendar.vue'
 import { CalendarItem } from '~/domain/calendar'
@@ -23,11 +24,11 @@ export default defineComponent({
   components: {
     CalendarView,
   },
-  setup(_, context: SetupContext) {
+  setup(_, ctx: SetupContext) {
     const state = reactive<State>({
       calendars: [],
     })
-    const unwatch = context.root.$store.watch<CalendarItem[]>(
+    const unwatch = ctx.root.$store.watch<CalendarItem[]>(
       (vuexState) => {
         return vuexState.calendars
       },
@@ -37,17 +38,15 @@ export default defineComponent({
     )
 
     onMounted(() => {
-      const authUser = context.root.$store.state?.authUser
-      context.root.$store.dispatch('getCalendarData', { authUser })
+      const authUser = ctx.root.$store.state?.authUser
+      ctx.root.$store.dispatch('getCalendarData', { authUser })
     })
 
     onUnmounted(() => {
       unwatch()
     })
 
-    return {
-      state,
-    }
+    return toRefs(state)
   },
 })
 </script>

--- a/pages/notifications/index.vue
+++ b/pages/notifications/index.vue
@@ -1,25 +1,21 @@
 <template>
   <div class="root">
     <v-sheet elevation="4" width="500">
-      <v-form v-model="state.valid" class="form">
+      <v-form v-model="valid" class="form">
         <h3>Push通知送信</h3>
-        <v-text-field v-model="state.uuid" label="uuid" :rules="[required]" />
+        <v-text-field v-model="uuid" label="uuid" :rules="[required]" />
 
-        <v-text-field
-          v-model="state.title"
-          label="タイトル"
-          :rules="[required]"
-        />
+        <v-text-field v-model="title" label="タイトル" :rules="[required]" />
 
         <v-textarea
-          v-model="state.body"
+          v-model="body"
           label="本文"
           auto-grow
           rows="1"
           :rules="[required]"
         />
 
-        <v-text-field v-model="state.urlScheme" label="URLスキーマ" />
+        <v-text-field v-model="urlScheme" label="URLスキーマ" />
 
         <div class="my-5">
           <v-btn color="primary" large @click="onPushNotidication">
@@ -42,7 +38,12 @@
 </style>
 
 <script lang="ts">
-import { defineComponent, reactive, SetupContext } from '@vue/composition-api'
+import {
+  defineComponent,
+  reactive,
+  SetupContext,
+  toRefs,
+} from '@vue/composition-api'
 import { post } from '~/modules/fetch.ts'
 
 type State = {
@@ -83,7 +84,7 @@ export default defineComponent({
     const required = (value: string) => !!value || '必須です.'
 
     return {
-      state,
+      ...toRefs(state),
       required,
       onPushNotidication,
     }

--- a/use/item.ts
+++ b/use/item.ts
@@ -1,0 +1,82 @@
+import { reactive, SetupContext, toRefs } from '@vue/composition-api'
+import {
+  findByID as findItemByID,
+  Item,
+} from 'peperomia-util/build/firestore/item'
+import {
+  findByItemID as findItemDetailByItemID,
+  ItemDetail,
+} from 'peperomia-util/build/firestore/itemDetail'
+import {
+  findByItemID as findCalendarByItemID,
+  Calendar,
+} from 'peperomia-util/build/firestore/calendar'
+import { post } from '~/modules/fetch.ts'
+
+type useFetchItem = {
+  item: Item | null
+  itemDetails: ItemDetail[]
+  calendar: Calendar | null
+  loading: boolean
+  postLoading: boolean
+}
+
+const useFetchItem = (ctx: SetupContext) => {
+  const firestore = ctx.root.$fireStore
+  const uid = ctx.root.$store.state.authUser?.uid
+
+  const state = reactive<useFetchItem>({
+    item: null,
+    itemDetails: [],
+    calendar: null,
+    loading: true,
+    postLoading: false,
+  })
+
+  const fetchItem = async (itemID: string) => {
+    state.loading = true
+    state.item = await findItemByID(firestore, uid, itemID)
+    state.itemDetails = await findItemDetailByItemID(firestore, uid, itemID)
+    state.calendar = await findCalendarByItemID(firestore, uid, itemID)
+
+    state.loading = false
+  }
+
+  const saveItem = async (item: Item): Promise<boolean> => {
+    state.postLoading = true
+    const res = await post(ctx, 'UpdateItem', {
+      item,
+    })
+
+    state.postLoading = false
+    return res.ok
+  }
+
+  const saveItemDetail = async (itemDetail: ItemDetail): Promise<boolean> => {
+    state.postLoading = true
+    const res = await post(ctx, 'UpdateItemDetail', {
+      itemDetail,
+    })
+
+    state.postLoading = false
+    return res.ok
+  }
+
+  const saveCalendar = async (calendar: Calendar): Promise<boolean> => {
+    const res = await post(ctx, 'UpdateCalendar', {
+      calendar,
+    })
+
+    return res.ok
+  }
+
+  return {
+    ...toRefs(state),
+    fetchItem,
+    saveItem,
+    saveItemDetail,
+    saveCalendar,
+  }
+}
+
+export default useFetchItem


### PR DESCRIPTION
## 関連 issue

- fixes #48 

## 対応内容

 - composition-api周りの不要なコードを修正
 - defineComponent<Props>でtypeを指定
 - reactive のreturnにtoRefs
 - propsはデフォルトでtemplateで取得できるので削除
 - ダイアログのitem取得はcustom hook形式に修正
 

## 開発用メモ
無し

